### PR TITLE
Feature/cancle user

### DIFF
--- a/src/main/java/com/chat/toktalk/controller/UserController.java
+++ b/src/main/java/com/chat/toktalk/controller/UserController.java
@@ -1,8 +1,10 @@
 package com.chat.toktalk.controller;
 
 import com.chat.toktalk.domain.User;
+import com.chat.toktalk.dto.PasswordForm;
 import com.chat.toktalk.security.LoginUserInfo;
 import com.chat.toktalk.service.UserService;
+import com.chat.toktalk.validator.PasswordValidator;
 import com.chat.toktalk.validator.UserValidator;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,6 +12,8 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
+
+
 @Log4j2
 @Controller
 @RequestMapping("/users")
@@ -20,6 +24,14 @@ public class UserController {
 
     @Autowired
     UserValidator userValidator;
+
+    @Autowired
+    PasswordValidator passwordValidator;
+
+    @GetMapping("/")
+    public String userAccount(){
+        return "my-account";
+    }
 
     @GetMapping(path = "/login")
     public String login() { return "users/login"; }
@@ -66,12 +78,20 @@ public class UserController {
 
         return null;
     }
+    @GetMapping("/delete")
+    public String deleteUserAccountForm(PasswordForm passwordForm, Model model){
+        model.addAttribute("user",passwordForm);
+        return "users/delete_form";
+    }
 
-    public String cancleUserAccount(){
-        //회원탈퇴기능
-            //회원가입상태,탈퇴상태구분
-            //실제 탈퇴시키는 것이 아님.
-            //탈퇴날짜추가.
-        return null;
+    @PostMapping("/delete")
+    public String cancleUserAccount(LoginUserInfo loginUserInfo, @ModelAttribute(name = "user") PasswordForm passwordForm, BindingResult bindingResult) {
+        passwordForm.setEmail(loginUserInfo.getEmail());
+        passwordValidator.validate(passwordForm, bindingResult);
+        if (bindingResult.hasErrors()) {
+            return "users/delete_form";
+        }
+        userService.deleteUser(loginUserInfo.getEmail());
+        return "redirect:/users/login";
     }
 }

--- a/src/main/java/com/chat/toktalk/domain/User.java
+++ b/src/main/java/com/chat/toktalk/domain/User.java
@@ -3,7 +3,6 @@ package com.chat.toktalk.domain;
 
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import lombok.*;
-
 import javax.persistence.*;
 import java.io.Serializable;
 import java.time.LocalDateTime;
@@ -33,8 +32,16 @@ public class User implements Serializable {
     private String nickname;
     // private UploadFile uploadFile; TODO 1:1 인데 어떻게 하지
     private LocalDateTime regdate;
+
     @Column(name = "last_seen_at")
     private LocalDateTime lastSeenAt;
+
+    @Column(name = "delete_date")
+    private LocalDateTime deleteDate;
+
+    @Column(name = "user_status")
+    @Enumerated(value = EnumType.STRING)
+    private UserStatus userStatus; //탈퇴 or 활성
 
     @JsonManagedReference
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)

--- a/src/main/java/com/chat/toktalk/domain/UserStatus.java
+++ b/src/main/java/com/chat/toktalk/domain/UserStatus.java
@@ -1,0 +1,5 @@
+package com.chat.toktalk.domain;
+
+public enum UserStatus {
+    NORMAL,DELETE
+}

--- a/src/main/java/com/chat/toktalk/dto/PasswordForm.java
+++ b/src/main/java/com/chat/toktalk/dto/PasswordForm.java
@@ -1,0 +1,12 @@
+package com.chat.toktalk.dto;
+
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PasswordForm {
+    private String email;
+    private String password;
+}

--- a/src/main/java/com/chat/toktalk/service/UserService.java
+++ b/src/main/java/com/chat/toktalk/service/UserService.java
@@ -3,9 +3,11 @@ package com.chat.toktalk.service;
 import com.chat.toktalk.domain.User;
 
 public interface UserService{
-    public void registerUser(User user);
-    public void addUser(User user);
-    public User getUserByEmail(String email);
+    void registerUser(User user);
+    void addUser(User user);
+    void deleteUser(String email);
+    User getUserByEmail(String email);
+
 
     User getUserById(Long invitedUserId);
 }

--- a/src/main/java/com/chat/toktalk/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/chat/toktalk/service/impl/UserServiceImpl.java
@@ -3,6 +3,7 @@ package com.chat.toktalk.service.impl;
 import com.chat.toktalk.domain.Role;
 import com.chat.toktalk.domain.RoleState;
 import com.chat.toktalk.domain.User;
+import com.chat.toktalk.domain.UserStatus;
 import com.chat.toktalk.repository.UserRepository;
 import com.chat.toktalk.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,11 +39,17 @@ public class UserServiceImpl implements UserService {
         Role role = new Role();
         role.setRoleState(RoleState.USER);
         user.addUserRole(role);
+        user.setUserStatus(UserStatus.NORMAL);
         userRepository.save(user);
 
-        //TODO
-        //회원상태 설정 필요
-  }
+    }
+
+    @Override
+    public void deleteUser(String email) {
+        User user = userRepository.findUserByEmail(email);
+        user.setUserStatus(UserStatus.DELETE);
+
+    }
 
     @Override
     public User getUserById(Long invitedUserId) {

--- a/src/main/java/com/chat/toktalk/validator/PasswordValidator.java
+++ b/src/main/java/com/chat/toktalk/validator/PasswordValidator.java
@@ -1,4 +1,39 @@
 package com.chat.toktalk.validator;
 
-public class PasswordValidator {
+import com.chat.toktalk.domain.User;
+import com.chat.toktalk.dto.PasswordForm;
+import com.chat.toktalk.service.UserService;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.Errors;
+import org.springframework.validation.Validator;
+
+@Log4j2
+@Component
+public class PasswordValidator implements Validator {
+
+    @Autowired
+    UserService userService;
+
+    @Autowired
+    PasswordEncoder passwordEncoder;
+
+    @Override
+    public boolean supports(Class<?> aClass) {
+        return PasswordForm.class.equals(aClass);
+    }
+
+    @Override
+    public void validate(Object object, Errors errors) {
+        PasswordForm passwordForm = (PasswordForm) object;
+        User user = userService.getUserByEmail(passwordForm.getEmail());
+
+        if(!passwordEncoder.matches(passwordForm.getPassword(),user.getPassword())){
+            errors.rejectValue("password","required","비밀번호가 같지 않습니다.");
+
+        }
+
+    }
 }

--- a/src/main/java/com/chat/toktalk/validator/PasswordValidator.java
+++ b/src/main/java/com/chat/toktalk/validator/PasswordValidator.java
@@ -1,0 +1,4 @@
+package com.chat.toktalk.validator;
+
+public class PasswordValidator {
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,7 +1,7 @@
-insert into user (id, email, password, nickname, regdate) VALUES (1, 'test', '{bcrypt}$2a$10$qS48/8nM2fSagy1di.whF.tutE/VZ9/wwOkGBcm.Ty8mOKLfwpv/G', '아이스베어', now());
-insert into user (id, email, password, nickname, regdate) VALUES (2, 'test2', '{bcrypt}$2a$10$qS48/8nM2fSagy1di.whF.tutE/VZ9/wwOkGBcm.Ty8mOKLfwpv/G', '갈색곰', now());
-insert into user (id, email, password, nickname, regdate) VALUES (3, 'test3', '{bcrypt}$2a$10$qS48/8nM2fSagy1di.whF.tutE/VZ9/wwOkGBcm.Ty8mOKLfwpv/G', '판다', now());
-insert into user (id, email, password, nickname, regdate) VALUES (4, 'bee@naver.com', '{bcrypt}$2a$10$qS48/8nM2fSagy1di.whF.tutE/VZ9/wwOkGBcm.Ty8mOKLfwpv/G', '땡벌', now());
+insert into user (id, email, password, nickname, regdate ,user_status) VALUES (1, 'test', '{bcrypt}$2a$10$qS48/8nM2fSagy1di.whF.tutE/VZ9/wwOkGBcm.Ty8mOKLfwpv/G', '아이스베어', now(),'NORMAL');
+insert into user (id, email, password, nickname, regdate ,user_status) VALUES (2, 'test2', '{bcrypt}$2a$10$qS48/8nM2fSagy1di.whF.tutE/VZ9/wwOkGBcm.Ty8mOKLfwpv/G', '갈색곰', now(),'NORMAL');
+insert into user (id, email, password, nickname, regdate ,user_status) VALUES (3, 'test3', '{bcrypt}$2a$10$qS48/8nM2fSagy1di.whF.tutE/VZ9/wwOkGBcm.Ty8mOKLfwpv/G', '판다', now(),'NORMAL');
+insert into user (id, email, password, nickname, regdate ,delete_date ,user_status) VALUES (4, 'bee@naver.com', '{bcrypt}$2a$10$qS48/8nM2fSagy1di.whF.tutE/VZ9/wwOkGBcm.Ty8mOKLfwpv/G', '땡벌', now(),now(),'DELETE');
 
 insert into user_roles(id, role_state, user_id) VALUES (1, 'USER', 1);
 insert into user_roles(id, role_state, user_id) VALUES (2, 'ADMIN', 1);

--- a/src/main/resources/templates/users/delete_form.html
+++ b/src/main/resources/templates/users/delete_form.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>회원가입</title>
+</head>
+<body>
+<h3>탈퇴할꺼야 ? 비번 입력해 </h3>
+<p>
+
+<form method="post" th:action="@{/users/cancle}" th:object="${user}" action="#">
+        <label for="password">password</label>
+        <input type="password" id="password" name="password" size="20" th:field="*{password}">
+        <small th:if="${#fields.hasErrors('password')}" th:errors="*{password}"/>
+    </div>
+    <button type="submit">Sign-Up</button>
+</form>
+</p>
+</body>

--- a/src/main/resources/templates/users/delete_form.html
+++ b/src/main/resources/templates/users/delete_form.html
@@ -8,7 +8,7 @@
 <h3>탈퇴할꺼야 ? 비번 입력해 </h3>
 <p>
 
-<form method="post" th:action="@{/users/cancle}" th:object="${user}" action="#">
+<form method="post" th:action="@{/users/delete}" th:object="${user}" action="#">
         <label for="password">password</label>
         <input type="password" id="password" name="password" size="20" th:field="*{password}">
         <small th:if="${#fields.hasErrors('password')}" th:errors="*{password}"/>

--- a/src/main/resources/templates/users/my-account.html
+++ b/src/main/resources/templates/users/my-account.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Channels</title>
+</head>
+<body>
+<nav>
+    <ul>
+        <li>
+            <a th:href="@{/users/delete}">회원탈퇴</a>
+        </li>
+    </ul>
+</nav>
+</body>
+</html>

--- a/src/main/resources/templates/users/my-details.html
+++ b/src/main/resources/templates/users/my-details.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Channels</title>
+</head>
+<body>
+
+</body>
+</html>


### PR DESCRIPTION
## 회원탈퇴기능 추가
 * 실제 탈퇴하는 것이 아니라 상태를 변경 함 (탈퇴 : DELETE, 회원 : NORMAL)

> 탈퇴를 하더라도 거래정보 유지 등을 위하여 이렇게 한다고는 들었는데
> 단순 채팅 사이트이기때문에 채팅 이력을 남겨놓지 않을꺼면
> 이렇게 해야되나 싶기도 함.

> 그리고 만약에 데이터를 삭제하지 않고 유지를 하게되면, 어디까지 보관되어야 되나 하는부분도 고민됨
> 그리고 이렇게 이력을 남겨놓게 되면 그 이메일은 다시 가입을 못하게 되는데
> 이것이 싫으면 컬럼을 하나 추가해서
> old 컬럼값 : 현재 이메일 정보
> email 컬럼값 :  UUID값
> 이렇게 변경하면 어떨까 생각함.
> 그러면 어짜피 관계된 다른 테이블 정보는 ID에 맵핑되어 있기 때문에 
> ID 중복검사시 안걸림. 
> 만약이렇게 되면 탈퇴정보를 따로 저장하는 테이블을 하나 만들어서 맵핑시켜야 할것 같음
