### PR TITLE
Front react

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ mvnw.cmd
 logs
 node_modules
 package-lock.json
+doc

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ http://ec2-13-124-151-134.ap-northeast-2.compute.amazonaws.com
 - NginX
 - Docker
 - Docker Swarm
-- Jenkins
 
 ## 미리보기
 ![shop01](./img/preview01.png)

--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -12,8 +12,6 @@ import ChatArea from './chat/ChatArea';
 import InputArea from './input/InputArea';
 import Footer from './footer/Footer';
 import WebSocket from './websocket/WebSocket';
-import NewChannelPopup from './popup/NewChannelPopup';
-import LeaveChannelModal from './popup/LeaveChannelModal';
 
 class Divider extends React.Component {
     render() {
@@ -36,9 +34,7 @@ class App extends React.Component {
         this.state = {
             routes: [],
             current: 0,
-            userId: 0,
-            showNewChannelPopup: false,
-            showLeaveChannelModal: false
+            userId: 0
         };
         this.chatAreas = new Map();
         this.addItem = this.addItem.bind(this);
@@ -52,22 +48,6 @@ class App extends React.Component {
         this.setState(() => {
             return {
                 userId: id
-            }
-        });
-    }
-
-    toggleNewChannelPopup() {
-        this.setState((prevState) => {
-            return {
-                showNewChannelPopup: !prevState.showNewChannelPopup
-            }
-        });
-    }
-
-    toggleLeaveChannelModal() {
-        this.setState((prevState) => {
-            return {
-                showLeaveChannelModal: !prevState.showLeaveChannelModal
             }
         });
     }
@@ -116,33 +96,19 @@ class App extends React.Component {
                     <div className="sidebar">
                         <Profile path="/images/woman.png" setUserId={this.setUserId.bind(this)}/>
                         <QuickSwitcher/>
-                        <GroupTag togglePopup={this.toggleNewChannelPopup.bind(this)}/>
+                        <GroupTag addNewChannel={this.addNewChannel.bind(this)}/>
                         <ChannelList ref={channels => this.channels = channels} addChatArea={this.addItem}
                                      switchChannel={this.switchChannel}/>
                         <DmTag/>
                         <DmList {...this.props}/>
                     </div>
-                    <Header ref={head => this.head = head} togglePopup={this.toggleLeaveChannelModal.bind(this)}/>
+                    <Header ref={head => this.head = head} userId={this.state.userId}/>
                     <Divider/>
                     {this.state.routes}
                     <InputArea ref={input => this.input = input} sendMessage={this.sendMessage}/>
                     <Footer/>
                     <WebSocket ref={sock => this.sock = sock} printMessage={this.printMessage}
                                markAsUnread={this.markAsUnread}/>
-                    {this.state.showNewChannelPopup ?
-                        <NewChannelPopup
-                            togglePopup={this.toggleNewChannelPopup.bind(this)}
-                            addNewChannel={this.addNewChannel.bind(this)}
-                        />
-                        : null
-                    }
-                    {this.state.showLeaveChannelModal ?
-                        <LeaveChannelModal
-                            togglePopup={this.toggleLeaveChannelModal.bind(this)} cId={this.state.current}
-                            userId={this.state.userId}
-                        />
-                        : null
-                    }
                 </div>
             </HashRouter>
         );

--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -62,6 +62,15 @@ class App extends React.Component {
         });
     }
 
+    removeItem(cId) {
+        this.setState((prevState) => {
+            return {
+                routes: prevState.routes.filter(item => item.props.cId != cId)
+            }
+        });
+        this.channels.removeChannel(cId);
+    }
+
     sendMessage(cId, text) {
         this.sock.sendChatMsg(cId, text);
     }
@@ -102,7 +111,8 @@ class App extends React.Component {
                         <DmTag/>
                         <DmList {...this.props}/>
                     </div>
-                    <Header ref={head => this.head = head} userId={this.state.userId}/>
+                    <Header ref={head => this.head = head} userId={this.state.userId} cId={this.state.current}
+                            removeItem={this.removeItem.bind(this)} switchChannel={this.switchChannel}/>
                     <Divider/>
                     {this.state.routes}
                     <InputArea ref={input => this.input = input} sendMessage={this.sendMessage}/>

--- a/frontend/src/components/App.js
+++ b/frontend/src/components/App.js
@@ -13,6 +13,7 @@ import InputArea from './input/InputArea';
 import Footer from './footer/Footer';
 import WebSocket from './websocket/WebSocket';
 import NewChannelPopup from './popup/NewChannelPopup';
+import LeaveChannelModal from './popup/LeaveChannelModal';
 
 class Divider extends React.Component {
     render() {
@@ -35,7 +36,9 @@ class App extends React.Component {
         this.state = {
             routes: [],
             current: 0,
-            showNewChannelPopup: false
+            userId: 0,
+            showNewChannelPopup: false,
+            showLeaveChannelModal: false
         };
         this.chatAreas = new Map();
         this.addItem = this.addItem.bind(this);
@@ -45,10 +48,26 @@ class App extends React.Component {
         this.markAsUnread = this.markAsUnread.bind(this);
     }
 
-    togglePopup() {
+    setUserId(id) {
+        this.setState(() => {
+            return {
+                userId: id
+            }
+        });
+    }
+
+    toggleNewChannelPopup() {
         this.setState((prevState) => {
             return {
                 showNewChannelPopup: !prevState.showNewChannelPopup
+            }
+        });
+    }
+
+    toggleLeaveChannelModal() {
+        this.setState((prevState) => {
+            return {
+                showLeaveChannelModal: !prevState.showLeaveChannelModal
             }
         });
     }
@@ -95,15 +114,15 @@ class App extends React.Component {
             <HashRouter>
                 <div>
                     <div className="sidebar">
-                        <Profile path="/images/woman.png"/>
+                        <Profile path="/images/woman.png" setUserId={this.setUserId.bind(this)}/>
                         <QuickSwitcher/>
-                        <GroupTag togglePopup={this.togglePopup.bind(this)}/>
+                        <GroupTag togglePopup={this.toggleNewChannelPopup.bind(this)}/>
                         <ChannelList ref={channels => this.channels = channels} addChatArea={this.addItem}
                                      switchChannel={this.switchChannel}/>
                         <DmTag/>
                         <DmList {...this.props}/>
                     </div>
-                    <Header ref={head => this.head = head}/>
+                    <Header ref={head => this.head = head} togglePopup={this.toggleLeaveChannelModal.bind(this)}/>
                     <Divider/>
                     {this.state.routes}
                     <InputArea ref={input => this.input = input} sendMessage={this.sendMessage}/>
@@ -112,7 +131,15 @@ class App extends React.Component {
                                markAsUnread={this.markAsUnread}/>
                     {this.state.showNewChannelPopup ?
                         <NewChannelPopup
-                            togglePopup={this.togglePopup.bind(this)} addNewChannel={this.addNewChannel.bind(this)}
+                            togglePopup={this.toggleNewChannelPopup.bind(this)}
+                            addNewChannel={this.addNewChannel.bind(this)}
+                        />
+                        : null
+                    }
+                    {this.state.showLeaveChannelModal ?
+                        <LeaveChannelModal
+                            togglePopup={this.toggleLeaveChannelModal.bind(this)} cId={this.state.current}
+                            userId={this.state.userId}
                         />
                         : null
                     }

--- a/frontend/src/components/chat/ChatArea.js
+++ b/frontend/src/components/chat/ChatArea.js
@@ -23,7 +23,6 @@ class ChatArea extends React.Component {
             for (let message of json) {
                 messages.push(<ChatContent key={Date.now() + message.id} {...message}/>);
             }
-            ;
             this.setState({
                 items: messages
             });

--- a/frontend/src/components/header/Header.js
+++ b/frontend/src/components/header/Header.js
@@ -4,7 +4,8 @@ class Header extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            title: ''
+            title: '',
+            cId: ''
         }
         this.switchChannel = this.switchChannel.bind(this);
     };
@@ -60,15 +61,11 @@ class Header extends React.Component {
         return (
             <div className="header" style={divStyle}>
                 <div style={innerDivStyle_1}>
-                    <div>
+                    <div className="dropdown">
                         <button style={{...buttonStyle, ...titleStyle}}>{this.state.title}</button>
-                    </div>
-                    <div>
-                        {/*<button style={Object.assign(buttonStyle, textStyle)}>
-                            <svg id="i-star" viewBox="0 0 32 32" width="15" height="15" fill="none" stroke="currentcolor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
-                                <path d="M16 2 L20 12 30 12 22 19 25 30 16 23 7 30 10 19 2 12 12 12 Z" />
-                            </svg>
-                        </button>*/}
+                        <div className="dropdown-content">
+                            <button style={buttonStyle} onClick={this.props.togglePopup}>나가기</button>
+                        </div>
                     </div>
                 </div>
                 <div style={innerDivStyle_2}>

--- a/frontend/src/components/header/Header.js
+++ b/frontend/src/components/header/Header.js
@@ -6,7 +6,6 @@ class Header extends React.Component {
         super(props);
         this.state = {
             title: '',
-            cId: '',
             showLeaveChannelModal: false
         }
         this.switchChannel = this.switchChannel.bind(this);
@@ -93,8 +92,9 @@ class Header extends React.Component {
                 </div>
                 {this.state.showLeaveChannelModal ?
                     <LeaveChannelModal
-                        togglePopup={this.toggleLeaveChannelModal} cId={this.state.cId}
-                        userId={this.props.userId}
+                        togglePopup={this.toggleLeaveChannelModal} cId={this.props.cId}
+                        userId={this.props.userId} removeItem={this.props.removeItem}
+                        switchChannel={this.props.switchChannel}
                     />
                     : null
                 }

--- a/frontend/src/components/header/Header.js
+++ b/frontend/src/components/header/Header.js
@@ -1,13 +1,16 @@
 import React from "react";
+import LeaveChannelModal from '../popup/LeaveChannelModal';
 
 class Header extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
             title: '',
-            cId: ''
+            cId: '',
+            showLeaveChannelModal: false
         }
         this.switchChannel = this.switchChannel.bind(this);
+        this.toggleLeaveChannelModal = this.toggleLeaveChannelModal.bind(this);
     };
 
     switchChannel(title) {
@@ -15,6 +18,14 @@ class Header extends React.Component {
             return {
                 title: title
             };
+        });
+    }
+
+    toggleLeaveChannelModal() {
+        this.setState((prevState) => {
+            return {
+                showLeaveChannelModal: !prevState.showLeaveChannelModal
+            }
         });
     }
 
@@ -64,7 +75,7 @@ class Header extends React.Component {
                     <div className="dropdown">
                         <button style={{...buttonStyle, ...titleStyle}}>{this.state.title}</button>
                         <div className="dropdown-content">
-                            <button style={buttonStyle} onClick={this.props.togglePopup}>나가기</button>
+                            <button style={buttonStyle} onClick={this.toggleLeaveChannelModal}>나가기</button>
                         </div>
                     </div>
                 </div>
@@ -80,6 +91,13 @@ class Header extends React.Component {
                         </button>
                     </div>
                 </div>
+                {this.state.showLeaveChannelModal ?
+                    <LeaveChannelModal
+                        togglePopup={this.toggleLeaveChannelModal} cId={this.state.cId}
+                        userId={this.props.userId}
+                    />
+                    : null
+                }
             </div>
         );
     }

--- a/frontend/src/components/header/Header.js
+++ b/frontend/src/components/header/Header.js
@@ -6,16 +6,18 @@ class Header extends React.Component {
         super(props);
         this.state = {
             title: '',
+            cType: '',
             showLeaveChannelModal: false
-        }
+        };
         this.switchChannel = this.switchChannel.bind(this);
         this.toggleLeaveChannelModal = this.toggleLeaveChannelModal.bind(this);
     };
 
-    switchChannel(title) {
+    switchChannel(title, cType) {
         this.setState(() => {
             return {
-                title: title
+                title: title,
+                cType: cType
             };
         });
     }
@@ -92,7 +94,7 @@ class Header extends React.Component {
                 </div>
                 {this.state.showLeaveChannelModal ?
                     <LeaveChannelModal
-                        togglePopup={this.toggleLeaveChannelModal} cId={this.props.cId}
+                        togglePopup={this.toggleLeaveChannelModal} cId={this.props.cId} cType={this.state.cType}
                         userId={this.props.userId} removeItem={this.props.removeItem}
                         switchChannel={this.props.switchChannel}
                     />

--- a/frontend/src/components/input/InputArea.js
+++ b/frontend/src/components/input/InputArea.js
@@ -14,22 +14,24 @@ class InputBox extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            cId: 0
+            cId: 0,
+            cType: ''
         };
         this.sendMessage = this.sendMessage.bind(this);
         this.switchChannel = this.switchChannel.bind(this);
     }
 
     sendMessage(e) {
-        this.props.sendMessage(this.state.cId, this._inputElement.value);
+        this.props.sendMessage(this.state.cId, this.state.cType, this._inputElement.value);
         this._inputElement.value = "";
         e.preventDefault();
     }
 
-    switchChannel(cId) {
+    switchChannel(cId, cType) {
         this.setState(() => {
             return {
-                cId: cId
+                cId: cId,
+                cType: cType
             };
         });
     }
@@ -41,7 +43,7 @@ class InputBox extends React.Component {
             fontSize: '15px',
             width: '80%',
             border: '0px'
-        }
+        };
         return (
             <div className="message-box">
                 <form onSubmit={this.sendMessage}>

--- a/frontend/src/components/popup/LeaveChannelModal.js
+++ b/frontend/src/components/popup/LeaveChannelModal.js
@@ -1,0 +1,52 @@
+import React from "react";
+import $ from "jquery";
+
+class LeaveChannelModal extends React.Component {
+    constructor(props) {
+        super(props);
+        this.leaveChannel = this.leaveChannel.bind(this);
+    }
+
+    leaveChannel() {
+        this.props.togglePopup();
+        $.ajax({
+            url: '/api/channelUsers/' + this.props.userId,
+            method: 'DELETE',
+            contentType: 'application/json',
+            data: JSON.stringify({channelId: this.props.cId})
+        }).done(json => {
+            // 해당 채널 컴포넌트 삭제
+        });
+    }
+
+    render() {
+        var modalContent = {
+            backgroundColor: '#fefefe',
+            margin: '15% auto',
+            padding: '20px',
+            border: '1px solid #888',
+            width: '30%'
+        };
+        var button = {
+            margin: '5px'
+        };
+        return (
+            <div className='popup'>
+                <div style={modalContent}>
+                    <span className="close" onClick={this.props.togglePopup}>&times;</span>
+                    <p>정말 나가실겁니까?</p>
+                    <div style={button}>
+                        <button className="btn btn-lg btn-primary" style={button}
+                                onClick={this.leaveChannel}>나가기
+                        </button>
+                        <button className="btn btn-lg btn-default" style={button}
+                                onClick={this.props.togglePopup}>취소
+                        </button>
+                    </div>
+                </div>
+            </div>
+        );
+    }
+}
+
+export default LeaveChannelModal;

--- a/frontend/src/components/popup/LeaveChannelModal.js
+++ b/frontend/src/components/popup/LeaveChannelModal.js
@@ -15,7 +15,8 @@ class LeaveChannelModal extends React.Component {
             contentType: 'application/json',
             data: JSON.stringify({channelId: this.props.cId})
         }).done(json => {
-            // 해당 채널 컴포넌트 삭제
+            this.props.removeItem(this.props.cId);
+            this.props.switchChannel(0, '');
         });
     }
 

--- a/frontend/src/components/popup/LeaveChannelModal.js
+++ b/frontend/src/components/popup/LeaveChannelModal.js
@@ -9,15 +9,21 @@ class LeaveChannelModal extends React.Component {
 
     leaveChannel() {
         this.props.togglePopup();
-        $.ajax({
-            url: '/api/channelUsers/' + this.props.userId,
-            method: 'DELETE',
-            contentType: 'application/json',
-            data: JSON.stringify({channelId: this.props.cId})
-        }).done(json => {
+        if (this.props.cType == 'PUBLIC') {
+            $.ajax({
+                url: '/api/channelUsers/' + this.props.userId,
+                method: 'DELETE',
+                contentType: 'application/json',
+                data: JSON.stringify({channelId: this.props.cId})
+            }).done(json => {
+                this.props.removeItem(this.props.cId);
+                this.props.switchChannel(0, '');
+            });
+        }
+        if (this.props.cType == 'DIRECT') {
             this.props.removeItem(this.props.cId);
             this.props.switchChannel(0, '');
-        });
+        }
     }
 
     render() {

--- a/frontend/src/components/popup/NewDirectMessagePopup.js
+++ b/frontend/src/components/popup/NewDirectMessagePopup.js
@@ -44,18 +44,14 @@ class NewDirectMessagePopup extends React.Component {
     }
 
     addNewDirectMessage() {
+        this.props.togglePopup();
         $.ajax({
             url: '/api/channels/direct',
             method: 'POST',
             contentType: 'application/json',
             data: JSON.stringify({partnerEmail: this.state.email})
         }).done(json => {
-            this.props.togglePopup();
-            console.log(json);
-
-        }).fail(xhr => { // 이미 존재하는 채널로 리다이렉트 ?
-            console.log(xhr);
-            console.log(xhr.status);
+            this.props.addNewChannel(json);
         });
     }
 

--- a/frontend/src/components/popup/NewDirectMessagePopup.js
+++ b/frontend/src/components/popup/NewDirectMessagePopup.js
@@ -1,0 +1,123 @@
+import React from "react";
+import $ from "jquery";
+import Avatar from '../sidebar/Avatar';
+
+class NewDirectMessagePopup extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            path: '/images/woman.png',
+            name: '',
+            email: '',
+            showNoResult: false,
+            showResult: false
+        };
+        this.findFriendByEmail = this.findFriendByEmail.bind(this);
+        this.addNewDirectMessage = this.addNewDirectMessage.bind(this);
+    }
+
+    findFriendByEmail(e) {
+        $.ajax({
+            url: '/api/users',
+            method: 'GET',
+            contentType: 'application/json',
+            data: {email: this._inputElement.value}
+        }).done(json => {
+            if ("" == json) {
+                this.setState(() => {
+                    return {
+                        showNoResult: true,
+                        showResult: false
+                    }
+                });
+            } else {
+                this.setState(() => {
+                    return {
+                        name: json.nickname,
+                        email: json.email,
+                        showNoResult: false,
+                        showResult: true
+                    }
+                });
+            }
+        });
+        e.preventDefault();
+    }
+
+    addNewDirectMessage() {
+        this.props.togglePopup();
+        $.ajax({
+            url: '/api/channelUsers/direct',
+            method: 'POST',
+            contentType: 'application/json',
+            data: {userId: this.props.userId, partnerEmail: this.state.email}
+        }).done(json => {
+            // 웹소켓 메세지로 상대방한테도 알려야 함
+        });
+    }
+
+    render() {
+        var modalContent = {
+            backgroundColor: '#fefefe',
+            margin: '15% auto',
+            padding: '20px',
+            border: '1px solid #888',
+            width: '30%'
+        };
+        var button = {
+            margin: '5px'
+        };
+        var inputStyle = {
+            margin: '3px',
+            padding: '7px 5px 7px 5px',
+            fontSize: '35px',
+            width: '80%',
+            border: '0px'
+        };
+        var noFriendDiv = {};
+        var resultDiv = {};
+        return (
+            <div className='popup'>
+                <div style={modalContent}>
+                    <span className="close" onClick={this.props.togglePopup}>&times;</span>
+                    <div>
+                        <form onSubmit={this.findFriendByEmail}>
+                            <input ref={(a) => this._inputElement = a}
+                                   placeholder="이메일로 친구 검색" style={inputStyle}/>
+                        </form>
+                    </div>
+                    {this.state.showNoResult ?
+                        <div style={noFriendDiv}>
+                            <p>찾으시는 친구가 존재하지 않습니다.</p>
+                        </div>
+                        : null
+                    }
+                    {this.state.showResult ?
+                        <div style={resultDiv}>
+                            <div className="row">
+                                <div className="column avatar">
+                                    <Avatar path={this.state.path}/>
+                                </div>
+                                <div className="column name">
+                                    {this.state.name}
+                                </div>
+                            </div>
+                            <div style={button}>
+                                <button className="btn btn-lg btn-primary" style={button}
+                                        onClick={this.addNewDirectMessage}>친구 추가
+                                </button>
+                                <button className="btn btn-lg btn-default" style={button}
+                                        onClick={this.props.togglePopup}>취소
+                                </button>
+                            </div>
+                        </div>
+                        : null
+                    }
+
+                </div>
+            </div>
+        );
+    }
+}
+
+export default NewDirectMessagePopup;

--- a/frontend/src/components/popup/NewDirectMessagePopup.js
+++ b/frontend/src/components/popup/NewDirectMessagePopup.js
@@ -18,12 +18,11 @@ class NewDirectMessagePopup extends React.Component {
 
     findFriendByEmail(e) {
         $.ajax({
-            url: '/api/users',
+            url: '/api/users/' + this._inputElement.value,
             method: 'GET',
-            contentType: 'application/json',
-            data: {email: this._inputElement.value}
+            contentType: 'application/json'
         }).done(json => {
-            if ("" == json) {
+            if (json === undefined) {
                 this.setState(() => {
                     return {
                         showNoResult: true,
@@ -50,9 +49,15 @@ class NewDirectMessagePopup extends React.Component {
             url: '/api/channelUsers/direct',
             method: 'POST',
             contentType: 'application/json',
-            data: {userId: this.props.userId, partnerEmail: this.state.email}
+            data: JSON.stringify({partnerEmail: this.state.email})
         }).done(json => {
+            console.log(json);
             // 웹소켓 메세지로 상대방한테도 알려야 함
+            if (json === undefined) {
+                // 이미 있는 방 - 그 방으로 이동
+            } else {
+                // 새로 방이 생성됨 - 컴포넌트 생성 후 그 방으로 이동
+            }
         });
     }
 
@@ -83,12 +88,12 @@ class NewDirectMessagePopup extends React.Component {
                     <div>
                         <form onSubmit={this.findFriendByEmail}>
                             <input ref={(a) => this._inputElement = a}
-                                   placeholder="이메일로 친구 검색" style={inputStyle}/>
+                                   placeholder="이름으로 대화 상대 검색" style={inputStyle}/>
                         </form>
                     </div>
                     {this.state.showNoResult ?
                         <div style={noFriendDiv}>
-                            <p>찾으시는 친구가 존재하지 않습니다.</p>
+                            <p>찾으시는 대화 상대가 존재하지 않습니다.</p>
                         </div>
                         : null
                     }
@@ -104,7 +109,7 @@ class NewDirectMessagePopup extends React.Component {
                             </div>
                             <div style={button}>
                                 <button className="btn btn-lg btn-primary" style={button}
-                                        onClick={this.addNewDirectMessage}>친구 추가
+                                        onClick={this.addNewDirectMessage}>대화 시작
                                 </button>
                                 <button className="btn btn-lg btn-default" style={button}
                                         onClick={this.props.togglePopup}>취소

--- a/frontend/src/components/popup/NewDirectMessagePopup.js
+++ b/frontend/src/components/popup/NewDirectMessagePopup.js
@@ -52,6 +52,8 @@ class NewDirectMessagePopup extends React.Component {
             data: JSON.stringify({partnerEmail: this.state.email})
         }).done(json => {
             this.props.addNewChannel(json);
+        }).fail(data => {
+            this.props.addNewChannel(data);
         });
     }
 

--- a/frontend/src/components/popup/NewDirectMessagePopup.js
+++ b/frontend/src/components/popup/NewDirectMessagePopup.js
@@ -44,20 +44,18 @@ class NewDirectMessagePopup extends React.Component {
     }
 
     addNewDirectMessage() {
-        this.props.togglePopup();
         $.ajax({
-            url: '/api/channelUsers/direct',
+            url: '/api/channels/direct',
             method: 'POST',
             contentType: 'application/json',
             data: JSON.stringify({partnerEmail: this.state.email})
         }).done(json => {
+            this.props.togglePopup();
             console.log(json);
-            // 웹소켓 메세지로 상대방한테도 알려야 함
-            if (json === undefined) {
-                // 이미 있는 방 - 그 방으로 이동
-            } else {
-                // 새로 방이 생성됨 - 컴포넌트 생성 후 그 방으로 이동
-            }
+
+        }).fail(xhr => { // 이미 존재하는 채널로 리다이렉트 ?
+            console.log(xhr);
+            console.log(xhr.status);
         });
     }
 

--- a/frontend/src/components/sidebar/ChannelList.js
+++ b/frontend/src/components/sidebar/ChannelList.js
@@ -47,7 +47,6 @@ class ChannelList extends React.Component {
                                            ref={(el => this.itemRefs.set(channel.id, el))}/>);
                 this.props.addChatArea(channel.id);
             }
-            ;
             this.setState({items: channels});
         });
     }
@@ -91,9 +90,9 @@ class ChannelItem extends React.Component {
         this.setState({unread: current + 1});
     }
 
-    switch(e) {
+    switch() {
         this.setState({unread: ''});
-        this.props.switchChannel(this.props.id, this.props.name);
+        this.props.switchChannel(this.props.id, this.props.name, 'PUBLIC');
     }
 
     render() {
@@ -102,7 +101,7 @@ class ChannelItem extends React.Component {
             paddingRight: '10px'
         };
         return (
-            <NavLink exact to={'/' + this.props.id} onClick={(e) => this.switch(e)}>
+            <NavLink exact to={'/' + this.props.id} onClick={() => this.switch()}>
                 <div className="row">
                     <div className="column">
                         {this.props.name}

--- a/frontend/src/components/sidebar/ChannelList.js
+++ b/frontend/src/components/sidebar/ChannelList.js
@@ -12,6 +12,7 @@ class ChannelList extends React.Component {
         };
         this.itemRefs = new Map();
         this.addNewChannel = this.addNewChannel.bind(this);
+        this.removeChannel = this.removeChannel.bind(this);
     }
 
     addNewChannel(channel) {
@@ -24,6 +25,14 @@ class ChannelList extends React.Component {
             };
         });
         this.props.addChatArea(channel.id);
+    }
+
+    removeChannel(cId) {
+        this.setState((prevState) => {
+            return {
+                items: prevState.items.filter(item => item.props.id != cId)
+            };
+        });
     }
 
     componentDidMount() {

--- a/frontend/src/components/sidebar/ChannelList.js
+++ b/frontend/src/components/sidebar/ChannelList.js
@@ -28,6 +28,7 @@ class ChannelList extends React.Component {
     }
 
     removeChannel(cId) {
+        this.itemRefs.set(cId, null);
         this.setState((prevState) => {
             return {
                 items: prevState.items.filter(item => item.props.id != cId)

--- a/frontend/src/components/sidebar/DmList.js
+++ b/frontend/src/components/sidebar/DmList.js
@@ -30,6 +30,7 @@ class DmList extends React.Component {
     }
 
     removeChannel(cId) {
+        this.itemRefs.set(cId, null);
         this.setState((prevState) => {
             return {
                 items: prevState.items.filter(item => item.props.id != cId)

--- a/frontend/src/components/sidebar/DmList.js
+++ b/frontend/src/components/sidebar/DmList.js
@@ -6,13 +6,57 @@ import {
 import Avatar from './Avatar';
 
 class DmList extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            items: []
+        };
+        this.itemRefs = new Map();
+        this.addNewChannel = this.addNewChannel.bind(this);
+        this.removeChannel = this.removeChannel.bind(this);
+    }
+
+    addNewChannel(channel) {
+        this.setState((prevState) => {
+            return {
+                items: prevState.items.concat(<DMItem switchChannel={this.props.switchChannel}
+                                                      key={Date.now() + channel.id}
+                                                      name={channel.name} id={channel.id}
+                                                      path="/images/woman.png"
+                                                      ref={(el => this.itemRefs.set(channel.id, el))}/>)
+            };
+        });
+        this.props.addChatArea(channel.id);
+    }
+
+    removeChannel(cId) {
+        this.setState((prevState) => {
+            return {
+                items: prevState.items.filter(item => item.props.id != cId)
+            };
+        });
+    }
+
+    componentDidMount() {
+        $.ajax({
+            url: '/api/channels',
+            method: 'GET'
+        }).done(json => {
+            var channels = [];
+            for (let channel of json) {
+                channels.push(<ChannelItem switchChannel={this.props.switchChannel} key={Date.now() + channel.id}
+                                           name={channel.name} id={channel.id}
+                                           ref={(el => this.itemRefs.set(channel.id, el))}/>);
+                this.props.addChatArea(channel.id);
+            }
+            this.setState({items: channels});
+        });
+    }
+
     render() {
         return (
             <div className="list dm">
-                <DMItem name="최연정" path="/images/woman.png"/>
-                <DMItem name="김세경" path="/images/woman.png"/>
-                <DMItem name="오세진" path="/images/man.png"/>
-                <DMItem name="홍길동" path="/images/man.png"/>
+                {this.state.items}
             </div>
         );
     }

--- a/frontend/src/components/sidebar/DmList.js
+++ b/frontend/src/components/sidebar/DmList.js
@@ -39,14 +39,15 @@ class DmList extends React.Component {
 
     componentDidMount() {
         $.ajax({
-            url: '/api/channels',
+            url: '/api/channels/direct',
             method: 'GET'
         }).done(json => {
             var channels = [];
             for (let channel of json) {
-                channels.push(<ChannelItem switchChannel={this.props.switchChannel} key={Date.now() + channel.id}
-                                           name={channel.name} id={channel.id}
-                                           ref={(el => this.itemRefs.set(channel.id, el))}/>);
+                channels.push(<DMItem switchChannel={this.props.switchChannel} key={Date.now() + channel.id}
+                                      name={channel.name} id={channel.id}
+                                      path="/images/woman.png"
+                                      ref={(el => this.itemRefs.set(channel.id, el))}/>);
                 this.props.addChatArea(channel.id);
             }
             this.setState({items: channels});
@@ -63,23 +64,64 @@ class DmList extends React.Component {
 }
 
 class DMItem extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            unread: ''
+        };
+        this.switch = this.switch.bind(this);
+        this.increaseUnread = this.increaseUnread.bind(this);
+    }
+
+    componentDidMount() {
+        $.ajax({
+            url: '/api/messages/unread',
+            method: 'GET',
+            data: {channelId: this.props.id}
+        }).done(json => {
+            if (json != null) {
+                this.setState({unread: json.unreadCnt});
+            }
+        });
+    }
+
+    increaseUnread() {
+        let current = this.state.unread;
+        if ('' == current) {
+            current = 0;
+        }
+        this.setState({unread: current + 1});
+    }
+
+    switch() {
+        this.setState({unread: ''});
+        this.props.switchChannel(this.props.id, this.props.name, 'DIRECT');
+    }
+
     render() {
+        var divStyle = {
+            textAlign: 'right',
+            paddingRight: '10px'
+        };
         return (
-            <a href="#">
+            <NavLink exact to={'/' + this.props.id} onClick={() => this.switch()}>
                 <div className="row">
                     <div className="column avatar">
                         <Avatar {...this.props}/>
-                    </div>
-                    <div className="column name">
-                        {this.props.name}
                     </div>
                     <div className="column status">
                         <svg className="icon">
                             <circle className="circle"/>
                         </svg>
                     </div>
+                    <div className="column name">
+                        {this.props.name}
+                    </div>
+                    <div style={divStyle} className="column">
+                        <span className="badge">{this.state.unread}</span>
+                    </div>
                 </div>
-            </a>
+            </NavLink>
         );
     }
 }

--- a/frontend/src/components/sidebar/DmTag.js
+++ b/frontend/src/components/sidebar/DmTag.js
@@ -47,7 +47,7 @@ class DmTag extends React.Component {
         return (
             <div style={divStyle}>
                 <div style={innerDivStyle_1}>
-                    <button style={buttonStyle}><b>연락처</b></button>
+                    <button style={buttonStyle}><b>1:1 대화</b></button>
                 </div>
                 <div style={innerDivStyle_2}>
                     <button style={buttonStyle} onClick={this.toggleNewDirectMessagePopup}>
@@ -59,7 +59,9 @@ class DmTag extends React.Component {
                     </button>
                 </div>
                 {this.state.showNewDirectMessagePopup ?
-                    <NewDirectMessagePopup togglePopup={this.toggleNewDirectMessagePopup}/>
+                    <NewDirectMessagePopup
+                        togglePopup={this.toggleNewDirectMessagePopup}
+                        addNewChannel={this.props.addNewChannel}/>
                     : null
                 }
             </div>

--- a/frontend/src/components/sidebar/DmTag.js
+++ b/frontend/src/components/sidebar/DmTag.js
@@ -1,6 +1,23 @@
 import React from "react";
+import NewDirectMessagePopup from '../popup/NewDirectMessagePopup';
 
 class DmTag extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            showNewDirectMessagePopup: false
+        };
+        this.toggleNewDirectMessagePopup = this.toggleNewDirectMessagePopup.bind(this);
+    }
+
+    toggleNewDirectMessagePopup() {
+        this.setState((prevState) => {
+            return {
+                showNewDirectMessagePopup: !prevState.showNewDirectMessagePopup
+            }
+        });
+    }
+
     render() {
         var buttonStyle = {
             backgroundColor: 'Transparent',
@@ -33,7 +50,7 @@ class DmTag extends React.Component {
                     <button style={buttonStyle}><b>연락처</b></button>
                 </div>
                 <div style={innerDivStyle_2}>
-                    <button style={buttonStyle}>
+                    <button style={buttonStyle} onClick={this.toggleNewDirectMessagePopup}>
                         <svg className="i-ban" viewBox="0 0 32 32" width="14" height="14" fill="none"
                              stroke="currentcolor"
                              stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
@@ -41,6 +58,10 @@ class DmTag extends React.Component {
                         </svg>
                     </button>
                 </div>
+                {this.state.showNewDirectMessagePopup ?
+                    <NewDirectMessagePopup togglePopup={this.toggleNewDirectMessagePopup}/>
+                    : null
+                }
             </div>
         );
     }

--- a/frontend/src/components/sidebar/GroupTag.js
+++ b/frontend/src/components/sidebar/GroupTag.js
@@ -1,8 +1,21 @@
 import React from "react";
+import NewChannelPopup from '../popup/NewChannelPopup';
 
 class GroupTag extends React.Component {
     constructor(props) {
         super(props);
+        this.state = {
+            showNewChannelPopup: false
+        };
+        this.toggleNewChannelPopup = this.toggleNewChannelPopup.bind(this);
+    }
+
+    toggleNewChannelPopup() {
+        this.setState((prevState) => {
+            return {
+                showNewChannelPopup: !prevState.showNewChannelPopup
+            }
+        });
     }
 
     render() {
@@ -37,7 +50,7 @@ class GroupTag extends React.Component {
                     <button style={buttonStyle}><b>그룹 대화</b></button>
                 </div>
                 <div style={innerDivStyle_2}>
-                    <button style={buttonStyle} onClick={this.props.togglePopup}>
+                    <button style={buttonStyle} onClick={this.toggleNewChannelPopup}>
                         <svg className="i-ban" viewBox="0 0 32 32" width="14" height="14" fill="none"
                              stroke="currentcolor"
                              stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
@@ -45,6 +58,13 @@ class GroupTag extends React.Component {
                         </svg>
                     </button>
                 </div>
+                {this.state.showNewChannelPopup ?
+                    <NewChannelPopup
+                        togglePopup={this.toggleNewChannelPopup}
+                        addNewChannel={this.props.addNewChannel}
+                    />
+                    : null
+                }
             </div>
         );
     }

--- a/frontend/src/components/sidebar/Profile.js
+++ b/frontend/src/components/sidebar/Profile.js
@@ -5,7 +5,8 @@ class Profile extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
-            name: ''
+            name: '',
+            id: ''
         };
     }
 
@@ -14,7 +15,8 @@ class Profile extends React.Component {
             url: '/api/users',
             method: 'GET'
         }).done(json => {
-            this.setState({name: json.nickname});
+            this.setState({name: json.nickname, id: json.id});
+            this.props.setUserId(json.id);
         });
     }
 

--- a/frontend/src/components/websocket/WebSocket.js
+++ b/frontend/src/components/websocket/WebSocket.js
@@ -12,6 +12,9 @@ class WebSocket extends React.Component {
     componentDidMount() {
         var scheme = window.location.protocol;
         var path = scheme + '//' + window.location.host + "/sock";
+        if (window.location.host == 'localhost:3000') {
+            path = "http://localhost:8080/sock";
+        }
         this.connection = new SockJS(path);
         this.connection.onheartbeat = e => {
             this.connection.send(JSON.stringify({'type': 'pong'}));

--- a/frontend/src/components/websocket/WebSocket.js
+++ b/frontend/src/components/websocket/WebSocket.js
@@ -28,7 +28,7 @@ class WebSocket extends React.Component {
                 data = e.data;
             }
             const type = data.type;
-            if ('CHAT' == type) {
+            if ('CHAT' === type) {
                 if (data.notification) {
                     this.props.markAsUnread(data.channelId); // notifyUnread(data.channelId);
                     // notificationf(data.channelId); // 구글 노티
@@ -40,20 +40,20 @@ class WebSocket extends React.Component {
                 this.props.printMessage(data);
             }
 
-            if ('SYSTEM' == type) {
+            if ('SYSTEM' === type) {
                 this.props.printMessage(data);
             }
 
-            if ('TYPING' == type) {
+            if ('TYPING' === type) {
 
             }
 
-            if ('CHANNEL_MARK' == type) {
+            if ('CHANNEL_MARK' === type) {
 
             }
 
-            if ('CHANNEL_JOINED' == type) {
-                if (data.channel.type == 'DIRECT') {
+            if ('CHANNEL_JOINED' === type) {
+                if (data.channel.type === 'DIRECT') {
                     this.props.addNewChannel(data.channel);
                 }
             }
@@ -66,7 +66,7 @@ class WebSocket extends React.Component {
     }
 
     sendChatMsg(cId, cType, text) {
-        if (!(text == "") && cId != 0) {
+        if (!(text === "") && cId !== 0) {
             this.connection.send(JSON.stringify({
                 'type': 'chat',
                 'channelId': cId,

--- a/frontend/src/components/websocket/WebSocket.js
+++ b/frontend/src/components/websocket/WebSocket.js
@@ -67,7 +67,7 @@ class WebSocket extends React.Component {
     }
 
     sendChatMsg(cId, text) {
-        if (!(text == "")) {
+        if (!(text == "") && cId != 0) {
             this.connection.send(JSON.stringify({'type': 'chat', 'channelId': cId, 'text': text}));
         }
     }

--- a/frontend/src/components/websocket/WebSocket.js
+++ b/frontend/src/components/websocket/WebSocket.js
@@ -53,11 +53,10 @@ class WebSocket extends React.Component {
             }
 
             if ('CHANNEL_JOINED' == type) {
-
+                if (data.channel.type == 'DIRECT') {
+                    this.props.addNewChannel(data.channel);
+                }
             }
-
-            // if ('UPLOAD_FILE' == type) {}
-            // if ('MESSAGES' == type) {}
 
             this.setState({
                 // messages: this.state.messages.concat([e.data])
@@ -66,11 +65,21 @@ class WebSocket extends React.Component {
         }
     }
 
-    sendChatMsg(cId, text) {
+    sendChatMsg(cId, cType, text) {
         if (!(text == "") && cId != 0) {
-            this.connection.send(JSON.stringify({'type': 'chat', 'channelId': cId, 'text': text}));
+            this.connection.send(JSON.stringify({
+                'type': 'chat',
+                'channelId': cId,
+                'channelType': cType,
+                'text': text
+            }));
         }
     }
+
+    notifyInvitation(cId, userId) {
+        this.connection.send(JSON.stringify({'type': 'invite_direct', 'channelId': cId, 'userId': userId}))
+    }
+
     render() {
         return (null);
     }

--- a/frontend/src/css/popup.css
+++ b/frontend/src/css/popup.css
@@ -7,7 +7,7 @@
     right: 0;
     bottom: 0;
     margin: auto;
-    background-color: rgba(0, 0, 0, 0.5);
+    /*background-color: rgba(0, 0, 0, 0.5);*/
     z-index: 2;
 }
 

--- a/frontend/src/css/popup.css
+++ b/frontend/src/css/popup.css
@@ -8,7 +8,7 @@
     bottom: 0;
     margin: auto;
     background-color: rgba(0, 0, 0, 0.5);
-    z-index: 10;
+    z-index: 2;
 }
 
 .popup_newchannel {
@@ -18,7 +18,7 @@
     width: 100%;
     height: 100%;
     background: white;
-    z-index: 11;
+    z-index: 3;
     text-align: center;
 }
 

--- a/frontend/src/css/popup.css
+++ b/frontend/src/css/popup.css
@@ -35,3 +35,48 @@
     z-index: 110;
 }
 */
+
+.dropdown {
+    position: relative;
+    display: inline-block;
+}
+
+.dropdown-content {
+    display: none;
+    position: absolute;
+    background-color: #f1f1f1;
+    margin-left: 5px;
+    border-radius: 5px;
+    z-index: 1;
+}
+
+.dropdown-content button {
+    color: black;
+    padding: 5px 10px;
+    text-decoration: none;
+    font-size: 14px;
+    display: block;
+}
+
+.dropdown-content:hover {
+    background-color: #e7e7e7
+}
+
+.dropdown:hover .dropdown-content {
+    display: block;
+}
+
+/* The Close Button */
+.close {
+    color: #aaa;
+    float: right;
+    font-size: 28px;
+    font-weight: bold;
+}
+
+.close:hover,
+.close:focus {
+    color: black;
+    text-decoration: none;
+    cursor: pointer;
+}

--- a/src/main/java/com/chat/toktalk/ToktalkApplication.java
+++ b/src/main/java/com/chat/toktalk/ToktalkApplication.java
@@ -7,14 +7,12 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
-import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.util.List;
 
-@EnableRedisHttpSession
 @SpringBootApplication
 public class ToktalkApplication implements WebMvcConfigurer {
 	public static void main(String[] args) {

--- a/src/main/java/com/chat/toktalk/amqp/MessageListener.java
+++ b/src/main/java/com/chat/toktalk/amqp/MessageListener.java
@@ -65,7 +65,7 @@ public class MessageListener{
     private void toIndividual(SocketMessage socketMessage) {
         Set<WebSocketSession> sessions = sessionManager.getWebSocketSessionsByUser(socketMessage.getUserId());
         if(sessions != null) {
-            sessions.stream().forEach(session -> {
+            sessions.forEach(session -> {
                 try {
                     String jsonStr = new ObjectMapper().writeValueAsString(socketMessage);
                     session.sendMessage(new TextMessage(jsonStr));

--- a/src/main/java/com/chat/toktalk/config/CustomWebSocketHandler.java
+++ b/src/main/java/com/chat/toktalk/config/CustomWebSocketHandler.java
@@ -1,13 +1,9 @@
 package com.chat.toktalk.config;
 
 import com.chat.toktalk.amqp.MessageSender;
-import com.chat.toktalk.domain.Channel;
-import com.chat.toktalk.domain.ChannelUser;
-import com.chat.toktalk.domain.Message;
-import com.chat.toktalk.domain.User;
+import com.chat.toktalk.domain.*;
 import com.chat.toktalk.dto.SendType;
 import com.chat.toktalk.dto.SocketMessage;
-import com.chat.toktalk.dto.UnreadMessageInfo;
 import com.chat.toktalk.service.*;
 import com.chat.toktalk.websocket.SessionManager;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -21,7 +17,6 @@ import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.TextWebSocketHandler;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -68,24 +63,6 @@ public class CustomWebSocketHandler extends TextWebSocketHandler {
 
         // Redis 웹소켓세션 등록
         redisService.addWebSocketSessionByUser(userId, session);
-
-        // 채널별로 읽지 않은 메세지 수 구해서 뿌려주기
-//        List<UnreadMessageInfo> unreadMessages = new ArrayList<>();
-//
-//        List<ChannelUser> channelUsers = channelUserService.getChannelUsersByUserId((Long)attributes.get("userId"));
-//
-//        for(ChannelUser channelUser : channelUsers){
-//            Long cnt = messageService.countUnreadnew UnreadMessageInfo(channelId, unread)MessageByChannelUser(channelUser);
-//            if(cnt != null){
-//                unreadMessages.add(new UnreadMessageInfo(channelUser.getChannel().getId(), cnt));
-//            }
-//        }
-//
-//        SocketMessage socketMessage = new SocketMessage(SendType.UNREAD);
-//        socketMessage.setUnreadMessages(unreadMessages);
-//        String jsonStr = objectMapper.writeValueAsString(socketMessage);
-//        logger.info(jsonStr);
-//        session.sendMessage(new TextMessage(jsonStr));
     }
 
     @Override
@@ -109,6 +86,21 @@ public class CustomWebSocketHandler extends TextWebSocketHandler {
         if ("invite_member".equals(type)) {
             inviteMember(map);
         }
+        if ("invite_direct".equals(type)) {
+            notifyInvitation(map);
+        }
+    }
+
+    private void notifyInvitation(HashMap<String, Object> map) {
+        Long channelId = Long.parseLong(map.get("channelId").toString());
+        Long userId = Long.parseLong(map.get("userId").toString());
+        Channel channel = channelService.getChannel(channelId);
+
+        SocketMessage socketMessage = new SocketMessage(SendType.CHANNEL_JOINED);
+        socketMessage.setUserId(userId);
+        socketMessage.setChannel(channel);
+        channel.setName(channel.getFirstUserName());
+        messageSender.sendMessage(socketMessage);
     }
 
     private void inviteMember(HashMap<String, Object> map) {
@@ -148,14 +140,14 @@ public class CustomWebSocketHandler extends TextWebSocketHandler {
         Long channelId = Long.parseLong(map.get("channelId").toString());
 
         /*
-         *   switch 하기 전 active channel 의 lastReadId 를 업데이트
+         *   switch 하기 전 active channel 의 lastReadCnt 를 업데이트
          */
         Long activeChannelId = redisService.getActiveChannelInfo(session);
         if(activeChannelId != null){
             ChannelUser alreadyUser = channelUserService.getChannelUser(activeChannelId, user.getId());
             if (alreadyUser != null) {
-//                alreadyUser.setLastReadId(redisService.getLastMessageIdByChannel(activeChannelId));
-                alreadyUser.setLastReadId(messageService.getLastIdByChannel(activeChannelId));
+//                alreadyUser.setLastReadCnt(redisService.getLastMessageIdByChannel(activeChannelId));
+                alreadyUser.setLastReadCnt(messageService.getTotalMessageCntByChannel(activeChannelId));
                 channelUserService.updateChannelUser(alreadyUser);
             }
         }
@@ -181,7 +173,7 @@ public class CustomWebSocketHandler extends TextWebSocketHandler {
             Long firstReadId = alreadyUser.getFirstReadId();
             messages = messageService.getMessagesByChannelUser(channelId, firstReadId);
             if(messages != null && messages.size() > 0){
-                alreadyUser.setLastReadId(messages.get(messages.size()-1).getId());
+                alreadyUser.setLastReadCnt(messages.get(messages.size() - 1).getId());
                 channelUserService.updateChannelUser(alreadyUser);
                 SocketMessage socketMessage = new SocketMessage(SendType.MESSAGES);
                 socketMessage.setChannelId(channelId);
@@ -230,18 +222,20 @@ public class CustomWebSocketHandler extends TextWebSocketHandler {
     private void handleChatMessage(WebSocketSession session, HashMap<String, Object> map) {
         Long channelId = new Long(map.get("channelId").toString());
         String message = (String) map.get("text");
+        String channelType = (String) map.get("channelType");
 
         Map<String, Object> attributes = session.getAttributes();
         Long userId = (Long) attributes.get("userId");
         String nickname = (String) attributes.get("nickname");
 
         // 1. 새 Message 엔티티 DB에 저장
-        Message messageNew = new Message();
-        messageNew.setUserId(userId);
-        messageNew.setNickname(nickname);
-        messageNew.setChannelId(channelId);
-        messageNew.setText(message);
-        messageService.addMessage(messageNew);
+        Message newMessage = new Message();
+        newMessage.setUserId(userId);
+        newMessage.setNickname(nickname);
+        newMessage.setChannelId(channelId);
+        newMessage.setChannelType(ChannelType.valueOf(channelType));
+        newMessage.setText(message);
+        messageService.addMessage(newMessage);
 
         // 2. 메세지큐에 내보내기
         SocketMessage socketMessage = new SocketMessage(SendType.CHAT);
@@ -260,22 +254,16 @@ public class CustomWebSocketHandler extends TextWebSocketHandler {
         Long userId = (Long) attributes.get("userId");
         sessionManager.removeWebSocketSession(userId, session);
 
-        // 마지막으로 보고 있던 채널의 lastReadId 를 업데이트
+        // 마지막으로 보고 있던 채널의 lastReadCnt 를 업데이트
         Long activeChannelId = redisService.getActiveChannelInfo(session);
         if(activeChannelId != null){
             ChannelUser alreadyUser = channelUserService.getChannelUser(activeChannelId, userId);
-//            alreadyUser.setLastReadId(redisService.getLastMessageIdByChannel(activeChannelId));
-            alreadyUser.setLastReadId(messageService.getLastIdByChannel(activeChannelId));
+            alreadyUser.setLastReadCnt(messageService.getTotalMessageCntByChannel(activeChannelId));
             channelUserService.updateChannelUser(alreadyUser);
         }
 
         // Redis 웹소켓세션 삭제
         redisService.removeWebSocketSessionByUser(userId, session);
         redisService.removeActiveChannelInfo(session);
-
-        // 레디스 정보 삭제
-        /*if(redisService.removeUser(attributes.get("userId").toString())){
-            System.out.println("삭제 성공!!!");
-        }*/
     }
 }

--- a/src/main/java/com/chat/toktalk/config/RabbitConfig.java
+++ b/src/main/java/com/chat/toktalk/config/RabbitConfig.java
@@ -26,4 +26,14 @@ public class RabbitConfig {
     //Delay Q, Dead Message Q
     //Queue_NAME은 Server이름 마다 다르게 처리.
 
+    /*@Bean
+    SimpleMessageListenerContainer fanoutContainer(ConnectionFactory connectionFactory,
+                                                   MessageListenerAdapter fanoutListenerAdapter) {
+        SimpleMessageListenerContainer container = new SimpleMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+        container.setQueueNames(new String[]{QUEUE_NAME1,QUEUE_NAME2});
+//        container.setQueueNames(QUEUE_NAME2);
+        container.setMessageListener(fanoutListenerAdapter);
+        return container;
+    }*/
 }

--- a/src/main/java/com/chat/toktalk/config/SessionConfig.java
+++ b/src/main/java/com/chat/toktalk/config/SessionConfig.java
@@ -1,0 +1,10 @@
+package com.chat.toktalk.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
+import org.springframework.session.web.context.AbstractHttpSessionApplicationInitializer;
+
+@Configuration
+@EnableRedisHttpSession
+public class SessionConfig extends AbstractHttpSessionApplicationInitializer {
+}

--- a/src/main/java/com/chat/toktalk/config/WebApplicationSecurityConfig.java
+++ b/src/main/java/com/chat/toktalk/config/WebApplicationSecurityConfig.java
@@ -49,7 +49,7 @@ public class WebApplicationSecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/users/login").permitAll()
                 .antMatchers("/users/**").authenticated()
                 .antMatchers("/h2-console/**").permitAll()
-                .antMatchers("/api/**").permitAll()
+                .antMatchers("/api/**").authenticated()
                 .anyRequest().hasAnyRole("ADMIN", "USER")
                 .and().headers().frameOptions().disable()
                 .and().formLogin()

--- a/src/main/java/com/chat/toktalk/controller/ChannelController.java
+++ b/src/main/java/com/chat/toktalk/controller/ChannelController.java
@@ -9,7 +9,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class ChannelController {
     @GetMapping
     public String channels() {
-//        return "channels/channels";
         return "public/index";
     }
 }

--- a/src/main/java/com/chat/toktalk/controller/api/ChannelApiController.java
+++ b/src/main/java/com/chat/toktalk/controller/api/ChannelApiController.java
@@ -106,10 +106,15 @@ public class ChannelApiController {
             return new ResponseEntity<>(direct, HttpStatus.CONFLICT);
         }
 
+        Channel newDirectChannel = new Channel();
+
+        if (userId.equals(partnerId)) {
+            newDirectChannel.setSelfConversation(true);
+        }
+
         ChannelUser firstChannelUser = createChannelUser(getUserByEmail(loginUserInfo.getEmail()));
         ChannelUser secondChannelUser = createChannelUser(getUserByEmail(params.get("partnerEmail")));
 
-        Channel newDirectChannel = new Channel();
         newDirectChannel.setType(ChannelType.DIRECT);
         newDirectChannel.setFirstUserId(userId);
         newDirectChannel.setSecondUserId(partnerId);

--- a/src/main/java/com/chat/toktalk/controller/api/ChannelApiController.java
+++ b/src/main/java/com/chat/toktalk/controller/api/ChannelApiController.java
@@ -55,6 +55,19 @@ public class ChannelApiController {
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 
+    @GetMapping(value = "direct/{channelId}")
+    public ResponseEntity<Channel> getDirectChannel(@PathVariable Long channelId, LoginUserInfo loginUserInfo) {
+        if (loginUserInfo != null) {
+            Channel channel = channelService.getChannel(channelId);
+            if (Objects.nonNull(channel)) {
+                channel.setName(channel.getFirstUserId().equals(loginUserInfo.getId()) ?
+                        channel.getSecondUserName() : channel.getFirstUserName());
+                return new ResponseEntity<>(channel, HttpStatus.OK);
+            }
+        }
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+
     @PostMapping
     public ResponseEntity<Channel> addChannel(@RequestBody ChannelForm channelForm, LoginUserInfo loginUserInfo){
         if(loginUserInfo != null){
@@ -74,7 +87,6 @@ public class ChannelApiController {
             }
 
             channel = channelService.addChannel(channel);
-//            redisService.createMessageIdCounter(channel.getId());
 
             return new ResponseEntity<>(channel, HttpStatus.OK);
         }
@@ -91,7 +103,7 @@ public class ChannelApiController {
 
         if (Objects.nonNull(direct)) {
             direct.setName(direct.getFirstUserId().equals(userId) ? direct.getSecondUserName() : direct.getFirstUserName());
-            return new ResponseEntity<>(direct, HttpStatus.OK);
+            return new ResponseEntity<>(direct, HttpStatus.CONFLICT);
         }
 
         ChannelUser firstChannelUser = createChannelUser(getUserByEmail(loginUserInfo.getEmail()));

--- a/src/main/java/com/chat/toktalk/controller/api/ChannelApiController.java
+++ b/src/main/java/com/chat/toktalk/controller/api/ChannelApiController.java
@@ -12,9 +12,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 @RestController
 @RequestMapping(value = "/api/channels", produces = "application/json; charset=utf8")
@@ -50,12 +48,12 @@ public class ChannelApiController {
             channelCreator.setIsOperator(true);
 
             Channel channel = new Channel();
-            channel.addChanneUser(channelCreator);
+            channel.addChannelUser(channelCreator);
             channel.setName(channelForm.getName());
-            if("private".equals(channelForm.getType())){
-                channel.setType("private");
+            if ("direct".equals(channelForm.getType())) {
+                channel.setType(ChannelType.DIRECT);
             } else {
-                channel.setType("public");
+                channel.setType(ChannelType.PUBLIC);
             }
 
             channel = channelService.addChannel(channel);

--- a/src/main/java/com/chat/toktalk/controller/api/ChannelUserApiController.java
+++ b/src/main/java/com/chat/toktalk/controller/api/ChannelUserApiController.java
@@ -1,0 +1,27 @@
+package com.chat.toktalk.controller.api;
+
+import com.chat.toktalk.security.LoginUserInfo;
+import com.chat.toktalk.service.ChannelUserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping(value = "/api/channelUsers")
+public class ChannelUserApiController {
+    @Autowired
+    private ChannelUserService channelUserService;
+
+    @DeleteMapping(value = "/{userId}")
+    public ResponseEntity<String> deleteChannelUser(@PathVariable Long userId, @RequestBody Map<String, Long> params, LoginUserInfo loginUserInfo) {
+        if (loginUserInfo != null) {
+            if (loginUserInfo.getId().equals(userId)) {
+                channelUserService.removeChannelUser(userId, params.get("channelId"));
+            }
+        }
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/chat/toktalk/controller/api/ChannelUserApiController.java
+++ b/src/main/java/com/chat/toktalk/controller/api/ChannelUserApiController.java
@@ -1,19 +1,32 @@
 package com.chat.toktalk.controller.api;
 
+import com.chat.toktalk.domain.Channel;
+import com.chat.toktalk.domain.ChannelType;
+import com.chat.toktalk.domain.ChannelUser;
+import com.chat.toktalk.domain.User;
 import com.chat.toktalk.security.LoginUserInfo;
+import com.chat.toktalk.service.ChannelService;
 import com.chat.toktalk.service.ChannelUserService;
+import com.chat.toktalk.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
+import java.util.Objects;
 
 @RestController
 @RequestMapping(value = "/api/channelUsers")
 public class ChannelUserApiController {
     @Autowired
     private ChannelUserService channelUserService;
+
+    @Autowired
+    private ChannelService channelService;
+
+    @Autowired
+    private UserService userService;
 
     @DeleteMapping(value = "/{userId}")
     public ResponseEntity<String> deleteChannelUser(@PathVariable Long userId, @RequestBody Map<String, Long> params, LoginUserInfo loginUserInfo) {
@@ -23,5 +36,40 @@ public class ChannelUserApiController {
             }
         }
         return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @PostMapping(value = "/direct")
+    public ResponseEntity<Channel> createDirectChannel(@RequestBody Map<String, String> params, LoginUserInfo loginUserInfo) {
+        Long userId = loginUserInfo.getId();
+        Long partnerId = getUserByEmail(params.get("partnerEmail")).getId();
+
+        Channel direct = channelService.getDirectChannel(userId, partnerId);
+
+        if (Objects.nonNull(direct)) {
+            return new ResponseEntity<>(HttpStatus.CONFLICT);
+        }
+
+        ChannelUser firstChannelUser = createChannelUser(getUserByEmail(loginUserInfo.getEmail()));
+        ChannelUser secondChannelUser = createChannelUser(getUserByEmail(params.get("partnerEmail")));
+
+        Channel newDirectChannel = new Channel();
+        newDirectChannel.setType(ChannelType.DIRECT);
+        newDirectChannel.setFirstUserId(userId);
+        newDirectChannel.setSecondUserId(partnerId);
+        newDirectChannel.addChannelUser(firstChannelUser);
+        newDirectChannel.addChannelUser(secondChannelUser);
+        channelService.addChannel(newDirectChannel);
+
+        return new ResponseEntity<>(newDirectChannel, HttpStatus.CREATED);
+    }
+
+    private ChannelUser createChannelUser(User user) {
+        ChannelUser channelUser = new ChannelUser();
+        channelUser.setUser(user);
+        return channelUser;
+    }
+
+    private User getUserByEmail(String email) {
+        return userService.findUserByEmail(email);
     }
 }

--- a/src/main/java/com/chat/toktalk/controller/api/ChannelUserApiController.java
+++ b/src/main/java/com/chat/toktalk/controller/api/ChannelUserApiController.java
@@ -1,32 +1,20 @@
 package com.chat.toktalk.controller.api;
 
-import com.chat.toktalk.domain.Channel;
-import com.chat.toktalk.domain.ChannelType;
-import com.chat.toktalk.domain.ChannelUser;
-import com.chat.toktalk.domain.User;
 import com.chat.toktalk.security.LoginUserInfo;
-import com.chat.toktalk.service.ChannelService;
 import com.chat.toktalk.service.ChannelUserService;
-import com.chat.toktalk.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
-import java.util.Objects;
 
 @RestController
 @RequestMapping(value = "/api/channelUsers")
 public class ChannelUserApiController {
+
     @Autowired
     private ChannelUserService channelUserService;
-
-    @Autowired
-    private ChannelService channelService;
-
-    @Autowired
-    private UserService userService;
 
     @DeleteMapping(value = "/{userId}")
     public ResponseEntity<String> deleteChannelUser(@PathVariable Long userId, @RequestBody Map<String, Long> params, LoginUserInfo loginUserInfo) {
@@ -36,40 +24,5 @@ public class ChannelUserApiController {
             }
         }
         return new ResponseEntity<>(HttpStatus.OK);
-    }
-
-    @PostMapping(value = "/direct")
-    public ResponseEntity<Channel> createDirectChannel(@RequestBody Map<String, String> params, LoginUserInfo loginUserInfo) {
-        Long userId = loginUserInfo.getId();
-        Long partnerId = getUserByEmail(params.get("partnerEmail")).getId();
-
-        Channel direct = channelService.getDirectChannel(userId, partnerId);
-
-        if (Objects.nonNull(direct)) {
-            return new ResponseEntity<>(HttpStatus.CONFLICT);
-        }
-
-        ChannelUser firstChannelUser = createChannelUser(getUserByEmail(loginUserInfo.getEmail()));
-        ChannelUser secondChannelUser = createChannelUser(getUserByEmail(params.get("partnerEmail")));
-
-        Channel newDirectChannel = new Channel();
-        newDirectChannel.setType(ChannelType.DIRECT);
-        newDirectChannel.setFirstUserId(userId);
-        newDirectChannel.setSecondUserId(partnerId);
-        newDirectChannel.addChannelUser(firstChannelUser);
-        newDirectChannel.addChannelUser(secondChannelUser);
-        channelService.addChannel(newDirectChannel);
-
-        return new ResponseEntity<>(newDirectChannel, HttpStatus.CREATED);
-    }
-
-    private ChannelUser createChannelUser(User user) {
-        ChannelUser channelUser = new ChannelUser();
-        channelUser.setUser(user);
-        return channelUser;
-    }
-
-    private User getUserByEmail(String email) {
-        return userService.findUserByEmail(email);
     }
 }

--- a/src/main/java/com/chat/toktalk/controller/api/MessageApiController.java
+++ b/src/main/java/com/chat/toktalk/controller/api/MessageApiController.java
@@ -61,14 +61,14 @@ public class MessageApiController {
         ChannelUser channelUser = channelUserService.getChannelUser(channelId, loginUserInfo.getId());
         if (channelUser != null) {
             Long unread = messageService.countUnreadMessageByChannelUser(channelUser);
-            if (unread != null) {
+            if (unread > 0) {
                 return new ResponseEntity<>(new UnreadMessageInfo(channelId, unread), HttpStatus.OK);
             }
         }
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 
-    @PostMapping(value = "/file") //ajax에서 호출하는 부분
+    @PostMapping(value = "/file")
     @ResponseBody
     @Transactional
     public String upload(MultipartHttpServletRequest multipartRequest, LoginUserInfo loginUserInfo) { //Multipart로 받는다.

--- a/src/main/java/com/chat/toktalk/controller/api/UserApiController.java
+++ b/src/main/java/com/chat/toktalk/controller/api/UserApiController.java
@@ -7,8 +7,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Objects;
 
 @RestController
 @RequestMapping(value = "/api/users", produces = "application/json; charset=utf8")
@@ -17,11 +20,24 @@ public class UserApiController {
     private UserService userService;
 
     @GetMapping
-    public ResponseEntity<User> user(LoginUserInfo loginUserInfo) {
+    public ResponseEntity<User> getUsers(LoginUserInfo loginUserInfo) {
         if (loginUserInfo != null) {
+//            loginUserInfo.getAuthorities().forEach(System.out::println);
             User user = userService.findUserByEmail(loginUserInfo.getEmail());
             return new ResponseEntity<>(user, HttpStatus.OK);
         }
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+
+    @GetMapping(value = "/{nickname}")
+    public ResponseEntity<User> getUserByName(@PathVariable String nickname) {
+
+        User user = userService.findUserByNickname(nickname);
+
+        if (Objects.nonNull(user)) {
+            return new ResponseEntity<>(user, HttpStatus.OK);
+        }
+
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 }

--- a/src/main/java/com/chat/toktalk/domain/Channel.java
+++ b/src/main/java/com/chat/toktalk/domain/Channel.java
@@ -27,7 +27,15 @@ public class Channel implements Serializable {
     private String name;
     private String url;
     private String data; // 메타데이터
+
+    @Enumerated(value = EnumType.STRING)
     private ChannelType type;
+
+    @Column(name = "first_user_id")
+    private Long firstUserId;
+
+    @Column(name = "second_user_id")
+    private Long secondUserId;
 
     @JsonBackReference
     @OneToMany(mappedBy = "channel", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
@@ -36,7 +44,7 @@ public class Channel implements Serializable {
     private Boolean freeze;
     private LocalDateTime regdate;
 
-    public void addChanneUser(ChannelUser channelUser){
+    public void addChannelUser(ChannelUser channelUser) {
         channelUsers.add(channelUser);
         if(channelUser.getChannel() != this){
             channelUser.setChannel(this);

--- a/src/main/java/com/chat/toktalk/domain/Channel.java
+++ b/src/main/java/com/chat/toktalk/domain/Channel.java
@@ -26,7 +26,7 @@ public class Channel implements Serializable {
     private Long id;
     private String name;
     private String url;
-    private String data; // 메타데이터
+    private String data;
 
     @Enumerated(value = EnumType.STRING)
     private ChannelType type;
@@ -36,6 +36,12 @@ public class Channel implements Serializable {
 
     @Column(name = "second_user_id")
     private Long secondUserId;
+
+    @Column(name = "first_user_name")
+    private String firstUserName;
+
+    @Column(name = "second_user_name")
+    private String secondUserName;
 
     @JsonBackReference
     @OneToMany(mappedBy = "channel", cascade = CascadeType.ALL, fetch = FetchType.LAZY)

--- a/src/main/java/com/chat/toktalk/domain/Channel.java
+++ b/src/main/java/com/chat/toktalk/domain/Channel.java
@@ -27,7 +27,7 @@ public class Channel implements Serializable {
     private String name;
     private String url;
     private String data; // 메타데이터
-    private String type; // public or private
+    private ChannelType type;
 
     @JsonBackReference
     @OneToMany(mappedBy = "channel", cascade = CascadeType.ALL, fetch = FetchType.LAZY)

--- a/src/main/java/com/chat/toktalk/domain/Channel.java
+++ b/src/main/java/com/chat/toktalk/domain/Channel.java
@@ -47,6 +47,9 @@ public class Channel implements Serializable {
     @OneToMany(mappedBy = "channel", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private List<ChannelUser> channelUsers = new ArrayList<>();
 
+    @Column(name = "self_conversation")
+    private Boolean selfConversation;
+
     private Boolean freeze;
     private LocalDateTime regdate;
 

--- a/src/main/java/com/chat/toktalk/domain/ChannelType.java
+++ b/src/main/java/com/chat/toktalk/domain/ChannelType.java
@@ -1,0 +1,5 @@
+package com.chat.toktalk.domain;
+
+public enum ChannelType {
+    PUBLIC, DIRECT
+}

--- a/src/main/java/com/chat/toktalk/domain/ChannelUser.java
+++ b/src/main/java/com/chat/toktalk/domain/ChannelUser.java
@@ -35,8 +35,8 @@ public class ChannelUser implements Serializable {
     @Column(name = "first_read_id") // 처음으로 읽은 메세지 id
     private Long firstReadId;
 
-    @Column(name = "last_read_id") // 마지막으로 읽은 메세지 id
-    private Long lastReadId;
+    @Column(name = "last_read_cnt") // 마지막으로 읽은 메세지 갯수
+    private Long lastReadCnt;
 
     @Column(name = "is_operator")
     private Boolean isOperator;

--- a/src/main/java/com/chat/toktalk/domain/Message.java
+++ b/src/main/java/com/chat/toktalk/domain/Message.java
@@ -24,15 +24,23 @@ public class Message implements Serializable {
     private Long id;
     private String text;
     private String type; // deleted or system - 삭제된메세지 혹은 시스템메세지 구분
-    private String data; // 메타데이터
+    private String data;
+
     @Column(name = "user_id")
     private Long userId;
     private String nickname;
+
     @Column(name = "channel_id")
     private Long channelId;
+
+    @Column(name = "channel_type")
+    @Enumerated(value = EnumType.STRING)
+    private ChannelType channelType;
+
     @OneToOne(mappedBy = "message", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @LazyToOne(LazyToOneOption.NO_PROXY)
     private UploadFile uploadFile;
+
     @JsonFormat(pattern = "a h:mm")
     private LocalDateTime regdate;
 }

--- a/src/main/java/com/chat/toktalk/domain/User.java
+++ b/src/main/java/com/chat/toktalk/domain/User.java
@@ -2,6 +2,7 @@ package com.chat.toktalk.domain;
 
 
 import com.fasterxml.jackson.annotation.JsonManagedReference;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 import javax.persistence.*;
 import java.io.Serializable;
@@ -28,6 +29,8 @@ public class User implements Serializable {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String email;
+
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     private String password;
     private String nickname;
     // private UploadFile uploadFile; TODO 1:1 인데 어떻게 하지

--- a/src/main/java/com/chat/toktalk/repository/ChannelRepository.java
+++ b/src/main/java/com/chat/toktalk/repository/ChannelRepository.java
@@ -3,11 +3,15 @@ package com.chat.toktalk.repository;
 import com.chat.toktalk.domain.Channel;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
-import java.util.Set;
 
 public interface ChannelRepository extends JpaRepository<Channel, Long> {
     @Query("select c from Channel c where c.type = 'public'")
     List<Channel> findAllPublicChannels();
+
+    @Query("select c from Channel c where (c.firstUserId = :firstUserId and c.secondUserId = :secondUserId)" +
+            "or (c.firstUserId = :secondUserId and c.secondUserId = :firstUserId)")
+    Channel findDirectChannelByIds(@Param("firstUserId") Long firstUserId, @Param("secondUserId") Long secondUserId);
 }

--- a/src/main/java/com/chat/toktalk/repository/MessageRepository.java
+++ b/src/main/java/com/chat/toktalk/repository/MessageRepository.java
@@ -11,6 +11,6 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
     @Query("select m from Message m where m.channelId = :channelId and m.id >= :firstReadId order by m.id asc")
     List<Message> findAllByChannelUser(@Param(value = "channelId") Long channelId, @Param(value = "firstReadId") Long firstReadId);
 
-    @Query("select max(m.id) from Message m where m.channelId = :channelId")
-    Long getLastId(@Param(value = "channelId") Long channelId);
+    @Query("select count(m) from Message m where m.channelId = :channelId")
+    Long countMessageByChannel(@Param(value = "channelId") Long channelId);
 }

--- a/src/main/java/com/chat/toktalk/repository/UserRepository.java
+++ b/src/main/java/com/chat/toktalk/repository/UserRepository.java
@@ -7,11 +7,13 @@ import org.springframework.data.repository.query.Param;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-     User findUsersByEmail(String email);
-     User findUserByEmail(String email);
+    User findUsersByEmail(String email);
 
-     @Query("SELECT oauth.user FROM OauthInfo oauth WHERE oauth.email = :email")
-     User findOauthUserByEmail(@Param("email")String email);
+    User findUserByEmail(String email);
 
+    @Query("SELECT oauth.user FROM OauthInfo oauth WHERE oauth.email = :email")
+    User findOauthUserByEmail(@Param("email") String email);
 
+    @Query("select u from User u where u.nickname = :nickname")
+    User findUserByNickname(@Param("nickname") String nickname);
 }

--- a/src/main/java/com/chat/toktalk/service/ChannelService.java
+++ b/src/main/java/com/chat/toktalk/service/ChannelService.java
@@ -11,4 +11,6 @@ public interface ChannelService {
     public Channel getChannel(Long channelId);
 
     public Channel addChannel(Channel channel);
+
+    public Channel getDirectChannel(Long userId, Long partnerId);
 }

--- a/src/main/java/com/chat/toktalk/service/ChannelService.java
+++ b/src/main/java/com/chat/toktalk/service/ChannelService.java
@@ -1,12 +1,13 @@
 package com.chat.toktalk.service;
 
 import com.chat.toktalk.domain.Channel;
+import com.chat.toktalk.domain.ChannelType;
 
 import java.util.List;
 import java.util.Set;
 
 public interface ChannelService {
-    public List<Channel> getChannelsByUser(Long userId);
+    public List<Channel> getChannelsByUser(Long userId, ChannelType type);
 
     public Channel getChannel(Long channelId);
 

--- a/src/main/java/com/chat/toktalk/service/MessageService.java
+++ b/src/main/java/com/chat/toktalk/service/MessageService.java
@@ -12,5 +12,5 @@ public interface MessageService {
 
     public Long countUnreadMessageByChannelUser(ChannelUser channelUser);
 
-    Long getLastIdByChannel(Long channelId);
+    Long getTotalMessageCntByChannel(Long channelId);
 }

--- a/src/main/java/com/chat/toktalk/service/RedisService.java
+++ b/src/main/java/com/chat/toktalk/service/RedisService.java
@@ -38,7 +38,7 @@ public interface RedisService {
 
     Boolean isChannelInSight(Long userId, Long channelId);
 
-    void createMessageIdCounter(Long channelId);
-    void increaseMessageIdByChannel(Long channelId);
-    Long getLastMessageIdByChannel(Long channelId);
+//    void createMessageIdCounter(Long channelId);
+//    void increaseMessageIdByChannel(Long channelId);
+//    Long getLastMessageIdByChannel(Long channelId);
 }

--- a/src/main/java/com/chat/toktalk/service/UserService.java
+++ b/src/main/java/com/chat/toktalk/service/UserService.java
@@ -4,6 +4,8 @@ import com.chat.toktalk.domain.User;
 import com.chat.toktalk.domain.UserStatus;
 import com.chat.toktalk.dto.UserDetailsForm;
 
+import java.util.Optional;
+
 public interface UserService{
     void registerUser(User user,UserStatus userStatus);
     void deleteUser(String email);
@@ -13,4 +15,6 @@ public interface UserService{
     void updateUserData(User user);
     void disConnectSocial(User user);
     void updatePassword(User user);
+
+    User findUserByNickname(String nickname);
 }

--- a/src/main/java/com/chat/toktalk/service/impl/ChannelServiceImpl.java
+++ b/src/main/java/com/chat/toktalk/service/impl/ChannelServiceImpl.java
@@ -23,11 +23,12 @@ public class ChannelServiceImpl implements ChannelService {
     ChannelUserRepository channelUserRepository;
 
     @Override
-    public List<Channel> getChannelsByUser(Long userId) {
+    public List<Channel> getChannelsByUser(Long userId, ChannelType type) {
         List<ChannelUser> channelUsers = channelUserRepository.findAllByUserId(userId);
         List<Channel> channels = new ArrayList<>(channelUsers.size());
-        channelUsers.stream().filter(user -> user.getChannel().getType() == ChannelType.PUBLIC)
+        channelUsers.stream().filter(user -> user.getChannel().getType() == type)
                 .forEach(user -> channels.add(user.getChannel()));
+
         return channels;
     }
 

--- a/src/main/java/com/chat/toktalk/service/impl/ChannelServiceImpl.java
+++ b/src/main/java/com/chat/toktalk/service/impl/ChannelServiceImpl.java
@@ -1,6 +1,7 @@
 package com.chat.toktalk.service.impl;
 
 import com.chat.toktalk.domain.Channel;
+import com.chat.toktalk.domain.ChannelType;
 import com.chat.toktalk.domain.ChannelUser;
 import com.chat.toktalk.repository.ChannelRepository;
 import com.chat.toktalk.repository.ChannelUserRepository;
@@ -25,7 +26,8 @@ public class ChannelServiceImpl implements ChannelService {
     public List<Channel> getChannelsByUser(Long userId) {
         List<ChannelUser> channelUsers = channelUserRepository.findAllByUserId(userId);
         List<Channel> channels = new ArrayList<>(channelUsers.size());
-        channelUsers.stream().forEach(channelUser -> channels.add(channelUser.getChannel()));
+        channelUsers.stream().filter(user -> user.getChannel().getType() == ChannelType.PUBLIC)
+                .forEach(user -> channels.add(user.getChannel()));
         return channels;
     }
 

--- a/src/main/java/com/chat/toktalk/service/impl/ChannelServiceImpl.java
+++ b/src/main/java/com/chat/toktalk/service/impl/ChannelServiceImpl.java
@@ -46,4 +46,9 @@ public class ChannelServiceImpl implements ChannelService {
 
         return newChannel;
     }
+
+    @Override
+    public Channel getDirectChannel(Long userId, Long partnerId) {
+        return channelRepository.findDirectChannelByIds(userId, partnerId);
+    }
 }

--- a/src/main/java/com/chat/toktalk/service/impl/RedisServiceImpl.java
+++ b/src/main/java/com/chat/toktalk/service/impl/RedisServiceImpl.java
@@ -35,14 +35,9 @@ public class RedisServiceImpl implements RedisService {
         this.redisTemplate.setValueSerializer(redisSerializer);
     }
 
-    //    @Override
-//    public void addUser(Long id, WebSocketSession session) {
-//        redisTemplate.opsForList().rightPush(id,session.getId());
-//    }
-
     @Override
     public void addChannelUser(Long channelId, String userId) {
-        redisTemplate.opsForList().rightPush(channelId.toString(), userId.toString());
+        redisTemplate.opsForList().rightPush(channelId.toString(), userId);
     }
 
     @Override
@@ -52,7 +47,7 @@ public class RedisServiceImpl implements RedisService {
 
     @Override
     public void addUserAtSocket(String socketId, String userId) {
-        redisTemplate.opsForList().rightPush(socketId.toString(), userId.toString());
+        redisTemplate.opsForList().rightPush(socketId.toString(), userId);
     }
 
     @Override
@@ -89,7 +84,7 @@ public class RedisServiceImpl implements RedisService {
     @Override
     public void addWebSocketSessionByUser(Long userId, WebSocketSession session) {
         String key = "user:"+userId.toString();
-        redisTemplate.opsForSet().add(key, session.getId().toString());
+        redisTemplate.opsForSet().add(key, session.getId());
         Set<String> sessionIdSet = redisTemplate.opsForSet().members(key);
         logger.info("userId " + userId +"의 웹소켓세션");
         for(String id : sessionIdSet){
@@ -101,8 +96,8 @@ public class RedisServiceImpl implements RedisService {
     public void removeWebSocketSessionByUser(Long userId, WebSocketSession session) {
         String key = "user:"+userId.toString();
         Set<String> sessionIdSet = redisTemplate.opsForSet().members(key);
-        if(sessionIdSet.contains(session.getId().toString())){
-            redisTemplate.opsForSet().remove(key, session.getId().toString());
+        if (sessionIdSet.contains(session.getId())) {
+            redisTemplate.opsForSet().remove(key, session.getId());
         }
         Set<String> sessions = redisTemplate.opsForSet().members(key);
         logger.info("user " + userId +"의 웹소켓세션");
@@ -132,13 +127,13 @@ public class RedisServiceImpl implements RedisService {
 
     @Override
     public void removeActiveChannelInfo(WebSocketSession session) {
-        String key = "websocketsession:"+session.getId().toString();
+        String key = "websocketsession:" + session.getId();
         redisTemplate.delete(key);
     }
 
     @Override
     public Long getActiveChannelInfo(WebSocketSession session) {
-        String key = "websocketsession:"+session.getId().toString();
+        String key = "websocketsession:" + session.getId();
         String channelId = (String) redisTemplate.opsForValue().get(key);
         if (channelId != null){
             return Long.parseLong(channelId);

--- a/src/main/java/com/chat/toktalk/service/impl/RedisServiceImpl.java
+++ b/src/main/java/com/chat/toktalk/service/impl/RedisServiceImpl.java
@@ -159,7 +159,7 @@ public class RedisServiceImpl implements RedisService {
         return isChannelInSight;
     }
 
-    @Override
+    /*@Override
     public void createMessageIdCounter(Long channelId) {
         String key = "channel:"+channelId.toString();
         redisTemplate.opsForValue().set(key, "0");
@@ -180,5 +180,5 @@ public class RedisServiceImpl implements RedisService {
         }
 
         return null;
-    }
+    }*/
 }

--- a/src/main/java/com/chat/toktalk/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/chat/toktalk/service/impl/UserServiceImpl.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 @Log4j2
 @Service
@@ -93,5 +94,10 @@ public class UserServiceImpl implements UserService {
     public User findOauthUserByEmail(String email){
         return userRepository.findOauthUserByEmail(email);
 
+    }
+
+    @Override
+    public User findUserByNickname(String nickname) {
+        return userRepository.findUserByNickname(nickname);
     }
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -9,7 +9,7 @@ insert into user_roles(id, role_state, user_id) VALUES (3, 'USER', 2);
 insert into user_roles(id, role_state, user_id) VALUES (4, 'USER', 3);
 insert into user_roles(id, role_state, user_id) VALUES (5, 'USER', 4);
 
-insert into channel(id, name, type, regdate) VALUES (1, 'general', 'public', now());
+insert into channel(id, name, type, regdate) VALUES (1, 'general', 'PUBLIC', now());
 
 insert into channel_user(id, user_id, channel_id, first_read_id, regdate, last_read_id) VALUES (1, 1, 1, 1, now(), 1);
 

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -11,11 +11,8 @@ insert into user_roles(id, role_state, user_id) VALUES (5, 'USER', 4);
 
 insert into channel(id, name, type, regdate) VALUES (1, 'general', 'PUBLIC', now());
 
-insert into channel_user(id, user_id, channel_id, first_read_id, regdate, last_read_id) VALUES (1, 1, 1, 1, now(), 1);
-
-insert into messages(id,text,user_id,nickname,channel_id,regdate) values (1,'greeting',1,'아이스베어',1,now());
-insert into messages(id,text,user_id,nickname,channel_id,regdate) values (2,'from',1,'아이스베어',1,now());
-insert into messages(id,text,user_id,nickname,channel_id,regdate) values (3,'toktalk',1,'아이스베어',1,now());
+insert into channel_user(id, user_id, channel_id, first_read_id, regdate, last_read_cnt) VALUES (1, 1, 1, 1, now(), 0);
+insert into channel_user(id, user_id, channel_id, first_read_id, regdate, last_read_cnt) VALUES (2, 4, 1, 1, now(), 0);
 
 insert into oauth_info(id,access_token,sub,name,picture,email,user_id)
 VALUES (1,'ya29.GlvXBbqz71mWDrxUVDqC2AiZTPHxHMIdch69Ml9NFeKmr9qfVL9g22QA64slm7wS4fiBqW7x24tbGBrMXlj0AqvStYEvPmQMYc4r7V4XgM_R-y9wOoBg-ZVKKss3','105547134406045421901','soso','https://lh3.googleusercontent.com/-EpeCRDESczo/AAAAAAAAAAI/AAAAAAAAA2A/dnUWLQwBFh4/photo.jpg','noriming2@gmail.com',1);

--- a/src/test/java/com/chat/toktalk/repository/jpa/ChannelRepositoryTest.java
+++ b/src/test/java/com/chat/toktalk/repository/jpa/ChannelRepositoryTest.java
@@ -1,0 +1,93 @@
+package com.chat.toktalk.repository.jpa;
+
+import com.chat.toktalk.domain.*;
+import com.chat.toktalk.repository.ChannelRepository;
+import com.chat.toktalk.repository.ChannelUserRepository;
+import com.chat.toktalk.repository.UserRepository;
+import net.bytebuddy.asm.Advice;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class ChannelRepositoryTest {
+
+    @Autowired
+    ChannelRepository channelRepository;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    ChannelUserRepository channelUserRepository;
+
+    @Test
+    public void testNotNull() {
+        assertThat(channelRepository).isNotNull();
+    }
+
+    private User createAndSaveTestUser() {
+        return createAndSaveTestUser("first@gmail.com");
+    }
+
+    private User createAndSaveTestUser(String email) {
+        Role role = new Role();
+        role.setRoleState(RoleState.TEST);
+
+        User testUser = new User();
+        testUser.setEmail(email);
+        testUser.setUserStatus(UserStatus.NORMAL);
+        testUser.addUserRole(role);
+
+        return userRepository.save(testUser);
+    }
+
+    private ChannelUser createAndSaveTestChannelUser(User testUser) {
+        ChannelUser channelUser = new ChannelUser();
+        channelUser.setUser(testUser);
+        return channelUserRepository.save(channelUser);
+    }
+
+    private Channel createChannel(ChannelType type) {
+        Channel channel = new Channel();
+        channel.setType(type);
+        return channel;
+    }
+
+    @Test
+    public void FindDirectChannelByIds() {
+        User firstUser = createAndSaveTestUser();
+        User secondUser = createAndSaveTestUser("second@gmail.com");
+
+        ChannelUser firstChannelUser = createAndSaveTestChannelUser(firstUser);
+        ChannelUser secondChannelUser = createAndSaveTestChannelUser(secondUser);
+
+        Channel testChannel = createChannel(ChannelType.DIRECT);
+        testChannel.addChannelUser(firstChannelUser);
+        testChannel.addChannelUser(secondChannelUser);
+        testChannel.setFirstUserId(firstUser.getId());
+        testChannel.setSecondUserId(secondUser.getId());
+        channelRepository.save(testChannel);
+
+        assertThat(channelRepository.findDirectChannelByIds(firstUser.getId(), secondUser.getId())).isNotNull();
+    }
+
+    @Test
+    public void testSaveChannel() {
+        User firstUser = createAndSaveTestUser();
+        ChannelUser firstChannelUser = createAndSaveTestChannelUser(firstUser);
+
+        Channel testChannel = createChannel(ChannelType.PUBLIC);
+        testChannel.addChannelUser(firstChannelUser);
+        Channel saveChannel = channelRepository.save(testChannel);
+
+        Channel findChannel = channelRepository.findById(saveChannel.getId()).get();
+
+        assertThat(findChannel.getId()).isEqualTo(saveChannel.getId());
+    }
+}

--- a/src/test/java/com/chat/toktalk/repository/jpa/ChannelRepositoryTest.java
+++ b/src/test/java/com/chat/toktalk/repository/jpa/ChannelRepositoryTest.java
@@ -4,17 +4,16 @@ import com.chat.toktalk.domain.*;
 import com.chat.toktalk.repository.ChannelRepository;
 import com.chat.toktalk.repository.ChannelUserRepository;
 import com.chat.toktalk.repository.UserRepository;
-import net.bytebuddy.asm.Advice;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest
+@DataJpaTest
 public class ChannelRepositoryTest {
 
     @Autowired
@@ -37,7 +36,7 @@ public class ChannelRepositoryTest {
 
     private User createAndSaveTestUser(String email) {
         Role role = new Role();
-        role.setRoleState(RoleState.TEST);
+        role.setRoleState(RoleState.USER);
 
         User testUser = new User();
         testUser.setEmail(email);

--- a/src/test/java/com/chat/toktalk/repository/jpa/ChannelUserRepositoryTest.java
+++ b/src/test/java/com/chat/toktalk/repository/jpa/ChannelUserRepositoryTest.java
@@ -1,0 +1,27 @@
+package com.chat.toktalk.repository.jpa;
+
+import com.chat.toktalk.domain.User;
+import com.chat.toktalk.repository.ChannelUserRepository;
+import com.chat.toktalk.repository.UserRepository;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@DataJpaTest
+public class ChannelUserRepositoryTest {
+
+    @Autowired
+    ChannelUserRepository channelUserRepository;
+
+    @MockBean
+    UserRepository userRepository;
+
+    @Test
+    public void testSaveChannelUser() {
+        User user = userRepository.save(new User());
+    }
+}

--- a/src/test/java/com/chat/toktalk/repository/jpa/UserRepositoryTest.java
+++ b/src/test/java/com/chat/toktalk/repository/jpa/UserRepositoryTest.java
@@ -1,0 +1,49 @@
+package com.chat.toktalk.repository.jpa;
+
+import com.chat.toktalk.domain.User;
+import com.chat.toktalk.repository.UserRepository;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@DataJpaTest
+public class UserRepositoryTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    public void testNotNull() {
+        assertThat(userRepository).isNotNull();
+    }
+
+    @Test
+    public void testGetOptionalUser() {
+        User user = userRepository.findUserByNickname("아이스베어");
+        Optional<User> optUser = Optional.ofNullable(user);
+        assertThat(optUser.get()).isNotNull();
+        assertThat(optUser.get().getNickname()).isEqualTo("아이스베어");
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void testThrowNoSuchElementException() {
+        Optional<User> optUser = Optional.ofNullable(userRepository.findUserByNickname("a"));
+        assertThat(optUser.isPresent()).isFalse();
+        optUser.get();
+    }
+
+    @Test
+    public void testNullUser() {
+        User user = userRepository.findUserByNickname("");
+        assertThat(Objects.nonNull(user)).isFalse();
+    }
+}


### PR DESCRIPTION
## 기능추가
- 1:1 대화 기능을 구현하였습니다.

## public channel vs direct channel
- 일반채널은 나가면 ChannelUser 가 삭제되는거라서 해당 유저는 그 이후로 채널에 속해있지 않게 됨
- 1:1대화는 나가면 그냥 채팅창이 시야에서 없어지는거고 채널에 여전히 속해있어서 상대방이 말을 걸면 다시 소환됨

## 수정사항
- unread (안읽은메세지수) 를 가져올 때, 해당 채널의 총 메세지 갯수 - 그 중 유저가 마지막으로 읽은 갯수 - 시스템메세지갯수 로 가져오도록 수정하였습니다.
- 기존엔 '갯수' 가 아니라 메세지 id로 가져왔었음. 여기서 오류를 발견. 채널별 메세지를 그냥 message 테이블에서 가져오는거라 message라는 엔티티의 id 를 가져와서  unread가 계산이 잘 안됐었음... 이젠고침.

